### PR TITLE
Remove duplicate "to"

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -21,7 +21,7 @@
 
 /*
 =head1 GV Handling and Stashes
-A GV is a structure which corresponds to to a Perl typeglob, ie *foo.
+A GV is a structure which corresponds to a Perl typeglob, ie *foo.
 It is a structure that holds a pointer to a scalar, an array, a hash etc,
 corresponding to $foo, @foo, %foo.
 

--- a/locale.c
+++ b/locale.c
@@ -248,7 +248,7 @@ static const char C_thousands_sep[] = "";
                              restore_toggled_locale_i(cat##_INDEX_, locale)
 
 /* On systems without LC_ALL, pretending it exists anyway simplifies things.
- * Choose a value for it that is very unlikely to to clash with any actual
+ * Choose a value for it that is very unlikely to clash with any actual
  * category */
 #  define FAKE_LC_ALL  PERL_INT_MIN
 

--- a/perlio.c
+++ b/perlio.c
@@ -3573,7 +3573,7 @@ PerlIOStdio_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR * ptr, SSize_t cnt)
          * problem is that one cannot know the signedness of char, and
          * more precisely the signedness of FILE._ptr.  The following
          * things have been tried, and they have all failed (across
-         * different compilers (remember that core needs to to build
+         * different compilers (remember that core needs to build
          * also with c++) and compiler options:
          *
          * - casting the RHS to (void*) -- works in *some* places


### PR DESCRIPTION
Correct spelling in comments

3 core C files affected
